### PR TITLE
FIX: Update README.md with actual Repo URL and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ repo-root/
 1. **Fork the repository** and clone it locally:
    
    ```sh
-   git clone https://github.com/your-username/your-repo.git
-   cd your-repo
+   git clone https://github.com/ByteXync/Commit-And-Conquer.git
+   cd Commit-And-Conquer
    ```
 4. Make your changes in the `main` branch of your fork.
 5. Commit your changes with a structured message:


### PR DESCRIPTION
Fixes issue #64

The Contributor guidelines earlier had dummy data like this:
```
git clone https://github.com/your-username/your-repo.git
cd your-repo
```
I have updated with actual data.


Team 8